### PR TITLE
Upgrade to phpunit 6.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
     "swagger"
   ],
   "require-dev": {
-    "phpunit/phpunit": "^5.7",
-    "phpunit/phpunit-mock-objects": "^3.4",
+    "phpunit/phpunit": "^6.4",
     "doctrine/cache": "^1.6",
     "satooshi/php-coveralls": "^1.0",
     "zendframework/zend-diactoros": "^1.4"

--- a/tests/Body/JsonBodyParserTest.php
+++ b/tests/Body/JsonBodyParserTest.php
@@ -26,22 +26,16 @@ class JsonBodyParserTest extends TestCase
         $this->parser = new JsonBodyParser();
     }
 
-    /**
-     * @test
-     */
-    public function canDecode()
+    public function testCanDecode()
     {
         $result = $this->parser->parse('{ "id": 1 }');
-        $this->assertEquals((object)['id' => 1], $result);
+        self::assertEquals((object)['id' => 1], $result);
     }
 
-    /**
-     * @test
-     */
-    public function willThrowJsonExceptionWhenNotDecodable()
+    public function testWillThrowJsonExceptionWhenNotDecodable()
     {
-        $this->expectException(JsonException::class);
-        $this->expectExceptionMessage('Syntax error');
+        self::expectException(JsonException::class);
+        self::expectExceptionMessage('Syntax error');
 
         $this->parser->parse('not json');
     }

--- a/tests/Body/JsonBodySerializerTest.php
+++ b/tests/Body/JsonBodySerializerTest.php
@@ -27,31 +27,22 @@ class JsonBodySerializerTest extends TestCase
         $this->serializer = new JsonBodySerializer();
     }
 
-    /**
-     * @test
-     */
-    public function canDecode()
+    public function testCanDecode()
     {
         $result = $this->serializer->serialize((object)['id' => 1]);
-        $this->assertEquals('{"id":1}', $result);
+        self::assertEquals('{"id":1}', $result);
     }
 
-    /**
-     * @test
-     */
-    public function willThrowJsonExceptionWhenNotEncodable()
+    public function testWillThrowJsonExceptionWhenNotEncodable()
     {
-        $this->expectException(JsonException::class);
-        $this->expectExceptionMessage('Malformed UTF-8 characters');
+        self::expectException(JsonException::class);
+        self::expectExceptionMessage('Malformed UTF-8 characters');
 
         $this->serializer->serialize("\xB1\x31");
     }
 
-    /**
-     * @test
-     */
-    public function willReturnContentType()
+    public function testWillReturnContentType()
     {
-        $this->assertSame('application/json', $this->serializer->getContentType());
+        self::assertSame('application/json', $this->serializer->getContentType());
     }
 }

--- a/tests/Functional/SimplePetStoreTest.php
+++ b/tests/Functional/SimplePetStoreTest.php
@@ -66,83 +66,62 @@ class SimplePetStoreTest extends TestCase
         };
     }
 
-    /**
-     * @test
-     */
-    public function willReturn404WhenNoMatchingPaths()
+    public function testWillReturn404WhenNoMatchingPaths()
     {
-        $this->assertSame(404, $this->dispatch(new ServerRequest())->getStatusCode());
+        self::assertSame(404, $this->dispatch(new ServerRequest())->getStatusCode());
     }
 
-    /**
-     * @test
-     */
-    public function tryingToPostPetWithoutBodyReturns400()
+    public function testTryingToPostPetWithoutBodyReturns400()
     {
         $response = $this->dispatch($this->createRequest('/pets', '', 'POST'));
 
-        $this->assertSame(400, $response->getStatusCode());
+        self::assertSame(400, $response->getStatusCode());
     }
 
-    /**
-     * @test
-     */
-    public function canCreatePet()
+    public function testCanCreatePet()
+    {
+        $response = $this->createPet();
+
+        self::assertSame(201, $response->getStatusCode());
+        $contents = $response->getBody()->getContents();
+        self::assertSame(['id' => 1, 'name' => 'doggo'], json_decode($contents, true));
+    }
+
+    public function testIdsWillAutoincrement()
     {
         $response = $this->dispatch($this->createRequest('/pets', json_encode(['name' => 'doggo'])));
 
-        $this->assertSame(201, $response->getStatusCode());
+        self::assertSame(201, $response->getStatusCode());
         $contents = $response->getBody()->getContents();
-        $this->assertSame(['id' => 1, 'name' => 'doggo'], json_decode($contents, true));
-    }
-
-    /**
-     * @test
-     */
-    public function idsWillAutoincrement()
-    {
+        self::assertSame(['id' => 1, 'name' => 'doggo'], json_decode($contents, true));
         $response = $this->dispatch($this->createRequest('/pets', json_encode(['name' => 'doggo'])));
 
-        $this->assertSame(201, $response->getStatusCode());
+        self::assertSame(201, $response->getStatusCode());
         $contents = $response->getBody()->getContents();
-        $this->assertSame(['id' => 1, 'name' => 'doggo'], json_decode($contents, true));
-        $response = $this->dispatch($this->createRequest('/pets', json_encode(['name' => 'doggo'])));
-
-        $this->assertSame(201, $response->getStatusCode());
-        $contents = $response->getBody()->getContents();
-        $this->assertSame(['id' => 2, 'name' => 'doggo'], json_decode($contents, true));
+        self::assertSame(['id' => 2, 'name' => 'doggo'], json_decode($contents, true));
     }
 
-    /**
-     * @test
-     */
-    public function canFetchPetById()
+    public function testCanFetchPetById()
     {
-        $this->canCreatePet();
+        $this->createPet();
 
         $response = $this->dispatch($this->createRequest('/pets/1'));
 
-        $this->assertSame(200, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode());
         $contents = $response->getBody()->getContents();
-        $this->assertSame(['id' => 1, 'name' => 'doggo'], json_decode($contents, true));
+        self::assertSame(['id' => 1, 'name' => 'doggo'], json_decode($contents, true));
     }
 
-    /**
-     * @test
-     */
-    public function willNotAttachResultSerializedWhenNotResponsing()
+    public function testWillNotAttachResultSerializedWhenNotResponsing()
     {
         $this->pipe->setResponding(false);
 
         $response = $this->dispatch($this->createRequest('/pets', json_encode(['name' => 'doggo'])));
 
-        $this->assertSame(418, $response->getStatusCode());
+        self::assertSame(418, $response->getStatusCode());
     }
 
-    /**
-     * @test
-     */
-    public function canMiddlewareAppendToPipe()
+    public function testCanMiddlewareAppendToPipe()
     {
         $this->pipe->append(new class implements MiddlewareInterface
         {
@@ -154,13 +133,10 @@ class SimplePetStoreTest extends TestCase
 
         $response = $this->dispatch($this->createRequest('/pets', json_encode(['name' => 'doggo'])));
 
-        $this->assertSame(302, $response->getStatusCode());
+        self::assertSame(302, $response->getStatusCode());
     }
 
-    /**
-     * @test
-     */
-    public function canAddPipeToPipe()
+    public function testCanAddPipeToPipe()
     {
         $this->pipe->setResponding(false);
 
@@ -186,7 +162,12 @@ class SimplePetStoreTest extends TestCase
 
         $response = $this->dispatch($this->createRequest('/pets', json_encode(['name' => 'doggo'])), $pipe);
 
-        $this->assertSame(405, $response->getStatusCode());
+        self::assertSame(405, $response->getStatusCode());
+    }
+
+    private function createPet()
+    {
+        return $this->dispatch($this->createRequest('/pets', json_encode(['name' => 'doggo'])));
     }
 
     private function dispatch(ServerRequestInterface $request, MiddlewarePipe $pipe = null): ResponseInterface

--- a/tests/OkStatusResolverTest.php
+++ b/tests/OkStatusResolverTest.php
@@ -26,10 +26,7 @@ class OkStatusResolverTest extends TestCase
         $this->resolver = new OkStatusResolver();
     }
 
-    /**
-     * @test
-     */
-    public function willReturn200ForNullResultWhen204NotAvailable()
+    public function testWillReturn200ForNullResultWhen204NotAvailable()
     {
         $statusCode = $this->resolver->resolve(
             null, $this->getMockBuilder(Operation::class)
@@ -37,13 +34,10 @@ class OkStatusResolverTest extends TestCase
             ->getMock()
         );
 
-        $this->assertSame(200, $statusCode);
+        self::assertSame(200, $statusCode);
     }
 
-    /**
-     * @test
-     */
-    public function willReturn204ForNullResultWhenAvailable()
+    public function testWillReturn204ForNullResultWhenAvailable()
     {
         /** @var \PHPUnit_Framework_MockObject_MockObject $operationMock */
         $operationMock = $operation = $this->getMockBuilder(Operation::class)
@@ -51,12 +45,12 @@ class OkStatusResolverTest extends TestCase
             ->getMock();
 
         $operationMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getStatusCodes')
             ->willReturn([200, 204]);
 
         $statusCode = $this->resolver->resolve(null, $operation);
 
-        $this->assertSame(204, $statusCode);
+        self::assertSame(204, $statusCode);
     }
 }

--- a/tests/OperationMatcherTest.php
+++ b/tests/OperationMatcherTest.php
@@ -78,17 +78,17 @@ class OperationMatcherTest extends TestCase
             ->getMock();
 
         $this->repository
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getUris')
             ->willReturn(['/path/to/document.yml']);
 
         $this->repository
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getIterator')
             ->willReturn(new RepositoryIterator($this->repository));
 
         $this->repository
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('get')
             ->willReturn($this->description);
 
@@ -107,8 +107,8 @@ class OperationMatcherTest extends TestCase
             Factory::createServerRequest([], 'GET', '/foo'), new Delegate([], $this->noopFn)
         );
 
-        $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertSame(404, $response->getStatusCode());
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertSame(404, $response->getStatusCode());
     }
 
     /**
@@ -122,8 +122,8 @@ class OperationMatcherTest extends TestCase
             Factory::createServerRequest([], 'POST', '/foo'), new Delegate([], $this->noopFn)
         );
 
-        $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertSame(405, $response->getStatusCode());
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertSame(405, $response->getStatusCode());
     }
 
     /**
@@ -140,7 +140,7 @@ class OperationMatcherTest extends TestCase
 
         $this->matcher->process(Factory::createServerRequest([], 'GET', '/foo'), new Delegate([], $next));
 
-        $this->assertTrue($matched);
+        self::assertTrue($matched);
     }
 
     /**
@@ -152,13 +152,13 @@ class OperationMatcherTest extends TestCase
 
         $matched = false;
         $next    = function (ServerRequestInterface $request) use (&$matched) {
-            $this->assertInstanceOf(Meta::class, $request->getAttribute(Meta::NAME));
+            self::assertInstanceOf(Meta::class, $request->getAttribute(Meta::NAME));
             $matched = true;
         };
 
         $this->matcher->process(Factory::createServerRequest([], 'GET', '/foo'), new Delegate([], $next));
 
-        $this->assertTrue($matched);
+        self::assertTrue($matched);
     }
 
     /**
@@ -172,13 +172,13 @@ class OperationMatcherTest extends TestCase
         $matched    = false;
         $valueOfBar = "value-of-bar";
         $next       = function (ServerRequestInterface $request) use (&$matched, $valueOfBar) {
-            $this->assertSame($valueOfBar, $request->getAttribute('bar'));
+            self::assertSame($valueOfBar, $request->getAttribute('bar'));
             $matched = true;
         };
 
         $this->matcher->process(Factory::createServerRequest([], 'GET', "/foo/$valueOfBar"), new Delegate([], $next));
 
-        $this->assertTrue($matched);
+        self::assertTrue($matched);
     }
 
     /**
@@ -192,13 +192,13 @@ class OperationMatcherTest extends TestCase
         $matched    = false;
         $valueOfBar = "1";
         $next       = function (ServerRequestInterface $request) use (&$matched, $valueOfBar) {
-            $this->assertSame($valueOfBar, $request->getAttribute('bar'));
+            self::assertSame($valueOfBar, $request->getAttribute('bar'));
             $matched = true;
         };
 
         $this->matcher->process(Factory::createServerRequest([], 'GET', "/foo/$valueOfBar"), new Delegate([], $next));
 
-        $this->assertTrue($matched);
+        self::assertTrue($matched);
 
         $matched    = false;
         $valueOfBar = "string-value";
@@ -208,7 +208,7 @@ class OperationMatcherTest extends TestCase
 
         $this->matcher->process(Factory::createServerRequest([], 'GET', "/foo/$valueOfBar"), new Delegate([], $next));
 
-        $this->assertFalse($matched);
+        self::assertFalse($matched);
     }
 
     /**
@@ -222,24 +222,24 @@ class OperationMatcherTest extends TestCase
         $matched    = false;
         $valueOfBar = "1.5";
         $next       = function (ServerRequestInterface $request) use (&$matched, $valueOfBar) {
-            $this->assertSame($valueOfBar, $request->getAttribute('bar'));
+            self::assertSame($valueOfBar, $request->getAttribute('bar'));
             $matched = true;
         };
 
         $this->matcher->process(Factory::createServerRequest([], 'GET', "/foo/$valueOfBar"), new Delegate([], $next));
 
-        $this->assertTrue($matched);
+        self::assertTrue($matched);
 
         $matched    = false;
         $valueOfBar = "5";
         $next       = function (ServerRequestInterface $request) use (&$matched, $valueOfBar) {
-            $this->assertSame($valueOfBar, $request->getAttribute('bar'));
+            self::assertSame($valueOfBar, $request->getAttribute('bar'));
             $matched = true;
         };
 
         $this->matcher->process(Factory::createServerRequest([], 'GET', "/foo/$valueOfBar"), new Delegate([], $next));
 
-        $this->assertTrue($matched);
+        self::assertTrue($matched);
 
         $matched    = false;
         $valueOfBar = "string-value";
@@ -249,7 +249,7 @@ class OperationMatcherTest extends TestCase
 
         $this->matcher->process(Factory::createServerRequest([], 'GET', "/foo/$valueOfBar"), new Delegate([], $next));
 
-        $this->assertFalse($matched);
+        self::assertFalse($matched);
     }
 
     /**
@@ -265,13 +265,13 @@ class OperationMatcherTest extends TestCase
         $matched    = false;
         $valueOfBar = "a";
         $next       = function (ServerRequestInterface $request) use (&$matched, $valueOfBar) {
-            $this->assertSame($valueOfBar, $request->getAttribute('bar'));
+            self::assertSame($valueOfBar, $request->getAttribute('bar'));
             $matched = true;
         };
 
         $this->matcher->process(Factory::createServerRequest([], 'GET', "/foo/$valueOfBar"), new Delegate([], $next));
 
-        $this->assertTrue($matched);
+        self::assertTrue($matched);
 
         $matched    = false;
         $valueOfBar = "abcd";
@@ -281,7 +281,7 @@ class OperationMatcherTest extends TestCase
 
         $this->matcher->process(Factory::createServerRequest([], 'GET', "/foo/$valueOfBar"), new Delegate([], $next));
 
-        $this->assertFalse($matched);
+        self::assertFalse($matched);
     }
 
     /**
@@ -291,18 +291,18 @@ class OperationMatcherTest extends TestCase
     {
         $this->mockOperation('/foo/{bar}', 'GET');
         $schema = $this->expectParameterType(Schema::TYPE_STRING, 2);
-        $schema->expects($this->exactly(2))->method('getEnum')->willReturn(['a', 'b']);
+        $schema->expects(self::exactly(2))->method('getEnum')->willReturn(['a', 'b']);
 
         $matched    = false;
         $valueOfBar = "a";
         $next       = function (ServerRequestInterface $request) use (&$matched, $valueOfBar) {
-            $this->assertSame($valueOfBar, $request->getAttribute('bar'));
+            self::assertSame($valueOfBar, $request->getAttribute('bar'));
             $matched = true;
         };
 
         $this->matcher->process(Factory::createServerRequest([], 'GET', "/foo/$valueOfBar"), new Delegate([], $next));
 
-        $this->assertTrue($matched);
+        self::assertTrue($matched);
 
         $matched    = false;
         $valueOfBar = "c";
@@ -312,7 +312,7 @@ class OperationMatcherTest extends TestCase
 
         $this->matcher->process(Factory::createServerRequest([], 'GET', "/foo/$valueOfBar"), new Delegate([], $next));
 
-        $this->assertFalse($matched);
+        self::assertFalse($matched);
     }
 
     /**
@@ -330,7 +330,7 @@ class OperationMatcherTest extends TestCase
 
         $this->matcher->process(Factory::createServerRequest([], 'GET', "/foo/null"), new Delegate([], $next));
 
-        $this->assertTrue($matched);
+        self::assertTrue($matched);
     }
 
     /**
@@ -348,7 +348,7 @@ class OperationMatcherTest extends TestCase
 
         $this->matcher->process(Factory::createServerRequest([], 'GET', "/foo/anything"), new Delegate([], $next));
 
-        $this->assertTrue($matched);
+        self::assertTrue($matched);
     }
 
     /**
@@ -366,7 +366,7 @@ class OperationMatcherTest extends TestCase
 
         $this->matcher->process(Factory::createServerRequest([], 'GET', "/foo/anything"), new Delegate([], $next));
 
-        $this->assertTrue($matched);
+        self::assertTrue($matched);
     }
 
     private function expectParameterType(string $type, int $count = 1): \PHPUnit_Framework_MockObject_MockObject
@@ -379,11 +379,11 @@ class OperationMatcherTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $parameter->expects($this->exactly($count))->method('getName')->willReturn('bar');
-        $parameter->expects($this->exactly($count))->method('getIn')->willReturn(Parameter::IN_PATH);
-        $parameter->expects($this->exactly($count))->method('getSchema')->willReturn($schema);
-        $schema->expects($this->exactly($count))->method('getType')->willReturn($type);
-        $this->operation->expects($this->exactly($count))->method('getParameters')->willReturn([$parameter]);
+        $parameter->expects(self::exactly($count))->method('getName')->willReturn('bar');
+        $parameter->expects(self::exactly($count))->method('getIn')->willReturn(Parameter::IN_PATH);
+        $parameter->expects(self::exactly($count))->method('getSchema')->willReturn($schema);
+        $schema->expects(self::exactly($count))->method('getType')->willReturn($type);
+        $this->operation->expects(self::exactly($count))->method('getParameters')->willReturn([$parameter]);
 
         return $schema;
     }
@@ -394,9 +394,9 @@ class OperationMatcherTest extends TestCase
      */
     private function mockOperation(string $pathString, string $method)
     {
-        $this->description->expects($this->any())->method('getPaths')->willReturn([$this->path]);
-        $this->path->expects($this->any())->method('getPath')->willReturn($pathString);
-        $this->path->expects($this->any())->method('getOperations')->willReturn([$this->operation]);
-        $this->operation->expects($this->any())->method('getMethod')->willReturn(strtolower($method));
+        $this->description->expects(self::any())->method('getPaths')->willReturn([$this->path]);
+        $this->path->expects(self::any())->method('getPath')->willReturn($pathString);
+        $this->path->expects(self::any())->method('getOperations')->willReturn([$this->operation]);
+        $this->operation->expects(self::any())->method('getMethod')->willReturn(strtolower($method));
     }
 }


### PR DESCRIPTION
> PHPUnit 5.7 is the old stable release series.
> It became stable on December 2, 2016.
> Support for PHPUnit 5 ends on February 2, 2018.
> — https://phpunit.de/