### PR TITLE
Allow non-breaking updates to psr/http-message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "kleijnweb/php-api-descriptions": "dev-master as v1.0.0-alpha5",
     "http-interop/http-middleware": "^0.4.1",
     "middlewares/utils": "^0.11.0",
-    "psr/http-message": "1.0",
+    "psr/http-message": "~1.0",
     "equip/dispatch": "^0.3.1"
   },
   "keywords": [


### PR DESCRIPTION
Currently v1.0.1 can't be installed. Tilde is slightly more restrictive than caret and the approach used by guzzle for instance: https://github.com/guzzle/psr7/blob/1.4.2/composer.json#L20.